### PR TITLE
ensure return_to location is properly stored

### DIFF
--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -21,7 +21,7 @@ module TwoFactorAuthentication
 
       def handle_failed_second_factor(scope)
         if request.format.present? and request.format.html?
-          session["#{scope}_return_tor"] = request.path if request.get?
+          session["#{scope}_return_to"] = request.path if request.get?
           redirect_to two_factor_authentication_path_for(scope)
         else
           render nothing: true, status: :unauthorized

--- a/spec/rails_app/app/controllers/home_controller.rb
+++ b/spec/rails_app/app/controllers/home_controller.rb
@@ -1,5 +1,4 @@
 class HomeController < ApplicationController
-  prepend_before_filter :store_location, only: :dashboard
   before_filter :authenticate_user!, only: :dashboard
 
   def index
@@ -8,9 +7,4 @@ class HomeController < ApplicationController
   def dashboard
   end
 
-  private
-
-  def store_location
-    store_location_for(:user, dashboard_path)
-  end
 end


### PR DESCRIPTION
Fixes small typo in session key for what Devise expects when retrieving stored `return_to` path for a given scope. 

[This scenario](https://github.com/Houdini/two_factor_authentication/blob/master/spec/features/two_factor_authenticatable_spec.rb#L33) actually already covers this issue, but the explicit call to `store_location_for` in the spec rails_app `HomeController` was masking the bug. Removing that filter gives proper coverage. 
