### PR TITLE
Adds integration spec to ensure authentication code is sent on sign in

### DIFF
--- a/spec/rails_app/app/models/user.rb
+++ b/spec/rails_app/app/models/user.rb
@@ -6,6 +6,10 @@ class User < ActiveRecord::Base
   has_one_time_password
 
   def send_two_factor_authentication_code
-    # No op
+    SMSProvider.send_message(to: phone_number, body: otp_code)
+  end
+
+  def phone_number
+    '14159341234'
   end
 end

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -16,6 +16,7 @@ module Dummy
 
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
+    config.autoload_paths += %W(#{config.root}/lib)
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/spec/rails_app/lib/sms_provider.rb
+++ b/spec/rails_app/lib/sms_provider.rb
@@ -1,0 +1,17 @@
+require 'ostruct'
+
+class SMSProvider
+  Message = Class.new(OpenStruct)
+
+  class_attribute :messages
+  self.messages = []
+
+  def self.send_message(opts = {})
+    self.messages << Message.new(opts)
+  end
+
+  def self.last_message
+    self.messages.last
+  end
+
+end

--- a/spec/support/features_spec_helper.rb
+++ b/spec/support/features_spec_helper.rb
@@ -4,6 +4,12 @@ module FeaturesSpecHelper
   def warden
     request.env['warden']
   end
+
+  def complete_sign_in_form_for(user)
+    fill_in "Email", with: user.email
+    fill_in "Password", with: 'password'
+    click_button "Sign in"
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/sms_provider.rb
+++ b/spec/support/sms_provider.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |c|
+  c.before(:each) do
+    SMSProvider.messages.clear
+  end
+end


### PR DESCRIPTION
Fills in missing coverage on the warden hook that calls `#send_authentication_code` on the logged in user directly after sign in.
