### PR TITLE
Use Strings and not Symbols for keys when storing variable in warden session

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -9,7 +9,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     render :show and return if params[:code].nil?
 
     if resource.authenticate_otp(params[:code])
-      warden.session(resource_name)[:need_two_factor_authentication] = false
+      warden.session(resource_name)['need_two_factor_authentication'] = false
       sign_in resource_name, resource, :bypass => true
       set_flash_message :notice, :success
       redirect_to stored_location_for(resource_name) || :root

--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -12,7 +12,7 @@ module TwoFactorAuthentication
       def handle_two_factor_authentication
         unless devise_controller?
           Devise.mappings.keys.flatten.any? do |scope|
-            if signed_in?(scope) and warden.session(scope)[:need_two_factor_authentication]
+            if signed_in?(scope) and warden.session(scope)['need_two_factor_authentication']
               handle_failed_second_factor(scope)
             end
           end
@@ -42,7 +42,7 @@ module Devise
   module Controllers
     module Helpers
       def is_fully_authenticated?
-        !session["warden.user.user.session"].try(:[], :need_two_factor_authentication)
+        !session["warden.user.user.session"].try(:[], 'need_two_factor_authentication')
       end
     end
   end

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -1,6 +1,6 @@
 Warden::Manager.after_authentication do |user, auth, options|
   if user.respond_to?(:need_two_factor_authentication?)
-    if auth.session(options[:scope])[:need_two_factor_authentication] = user.need_two_factor_authentication?(auth.request)
+    if auth.session(options[:scope])['need_two_factor_authentication'] = user.need_two_factor_authentication?(auth.request)
       user.send_two_factor_authentication_code
     end
   end


### PR DESCRIPTION
I run into this problem after updating my application to Rails 4.1. The application stopped displaying 2FA screen even though the user had otp_secret_key set etc. After research, it occured that `warden.session(resource_name)[:need_two_factor_authentication]` always returned `false` regardless of the value we gave it elsewhere (see lib/two_factor_authentication/controllers/helpers.rb#15).

I think it is somehow related to this change: http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#cookies-serializer (and the way that now all keys are stringified when you store cookie/session variable).

So, this happens after update to Rails 4.1:

``` ruby
warden.session(resource_name)[:need_two_factor_authentication] = true
# ... some request
warden.session(resource_name)[:need_two_factor_authentication] # => nil
```

BUT it can be easily remedied by using string keys for cookie/session variables:

``` ruby
warden.session(resource_name)[:need_two_factor_authentication] = true
# ... some request
warden.session(resource_name)['need_two_factor_authentication'] # => true
```

and:

``` ruby
warden.session(resource_name)['need_two_factor_authentication'] = true
# ... some request
warden.session(resource_name)['need_two_factor_authentication'] # => true
```

So, I think it's best to always store and read session variables using String keys (and not Symbol keys). If you look into Devise gem sources, they also use only String keys to read/write to warden session.

This change is backwards-compatible, ie. the gem will work the same in older Rails and in existing applications.
