### PR TITLE
Preserve query parameters in _return_to for redirect.

### DIFF
--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -21,7 +21,7 @@ module TwoFactorAuthentication
 
       def handle_failed_second_factor(scope)
         if request.format.present? and request.format.html?
-          session["#{scope}_return_to"] = request.path if request.get?
+          session["#{scope}_return_to"] = "#{request.path}?#{request.query_string}" if request.get?
           redirect_to two_factor_authentication_path_for(scope)
         else
           render nothing: true, status: :unauthorized

--- a/spec/features/two_factor_authenticatable_spec.rb
+++ b/spec/features/two_factor_authenticatable_spec.rb
@@ -45,7 +45,7 @@ feature "User of two factor authentication" do
     end
 
     scenario "is redirected to TFA when path requires authentication" do
-      visit dashboard_path
+      visit dashboard_path + "?A=param%20a&B=param%20b"
 
       expect(page).to_not have_content("Your Personal Dashboard")
 
@@ -54,6 +54,8 @@ feature "User of two factor authentication" do
 
       expect(page).to have_content("Your Personal Dashboard")
       expect(page).to have_content("You are signed in as Marissa")
+      expect(page).to have_content("Param A is param a")
+      expect(page).to have_content("Param B is param b")
     end
 
     scenario "is locked out after max failed attempts" do

--- a/spec/rails_app/app/views/home/dashboard.html.erb
+++ b/spec/rails_app/app/views/home/dashboard.html.erb
@@ -4,4 +4,8 @@
 
 <p>Your registered email address is <%= current_user.email %></p>
 
+<p> Param A is <%= params[:A] %></p>
+
+<p> Param B is <%= params[:B] %></p>
+
 <p>You can only see this page after successfully completing two factor authentication</p>


### PR DESCRIPTION
Storing just request.path drops the query string which makes two factory
authentication less useful when the guarded page needs those parameters.

This brings the two factor authentication redirect behavior in line with
devise's.
