### PR TITLE
Make Warden after_authentication customizable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,30 @@ task :update_users_with_otp_secret_key  => :environment do
 end
 ```
 
+#### Executing some code before the OTP is sent when the user signs in
+
+In some cases, you might want to perform some action right after the user signs
+in, but before the OTP is sent. To define this action, create an `OtpSender`
+class that takes the current user as its parameter, and define a `#before_otp`
+instance method. For example:
+```ruby
+class OtpSender
+  def initialize(user)
+    @user = user
+  end
+
+  def before_otp
+    if @user.unconfirmed_mobile.present?
+      reset_mobile_2fa_state
+    end
+  end
+
+  def reset_mobile_2fa_state
+    @user.update(unconfirmed_mobile: nil)
+  end
+end
+```
+
 ### Example
 
 [TwoFactorAuthenticationExample](https://github.com/Houdini/TwoFactorAuthenticationExample)

--- a/lib/two_factor_authentication.rb
+++ b/lib/two_factor_authentication.rb
@@ -5,7 +5,6 @@ require "active_model"
 require "active_record"
 require "active_support/core_ext/class/attribute_accessors"
 require "cgi"
-require "rotp"
 
 module Devise
   mattr_accessor :max_login_attempts

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -1,4 +1,8 @@
 Warden::Manager.after_authentication do |user, auth, options|
+  if Object.const_defined?('OtpSender') && OtpSender.new(user).respond_to?(:before_otp)
+    OtpSender.new(user).before_otp
+  end
+
   if user.respond_to?(:need_two_factor_authentication?) &&
       !auth.env["action_dispatch.cookies"].signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME]
     if auth.session(options[:scope])[TwoFactorAuthentication::NEED_AUTHENTICATION] = user.need_two_factor_authentication?(auth.request)

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -1,4 +1,6 @@
 require 'two_factor_authentication/hooks/two_factor_authenticatable'
+require 'rotp'
+
 module Devise
   module Models
     module TwoFactorAuthenticatable


### PR DESCRIPTION
This modifies the generator so that it takes the Warden `after_authentication` code in [lib/two_factor_authentication/hooks/two_factor_authenticatable.rb](https://github.com/Houdini/two_factor_authentication/blob/master/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb) and copies it to `config/initializers/after_authentication.rb`, which allows people to customize what happens after sign in if desired.

I also added a conditional to the model generator so that if the
`:two_factor_authenticatable` module has already been added, it
doesn't do it again when you run the generator. This makes this
change backwards compatible.

Closes #49.