### PR TITLE
Test against Ruby 2.2 and Rails 4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ env:
   - "RAILS_VERSION=3.2.0"
   - "RAILS_VERSION=4.0.0"
   - "RAILS_VERSION=4.1.1"
+  - "RAILS_VERSION=4.2.4"
   - "RAILS_VERSION=master"
 
 rvm:
   - 1.9.3
   - 2.0
   - 2.1
+  - 2.2
 
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ rails = case rails_version
 
 gem "rails", rails
 
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
+  gem "test-unit", "~> 3.0"
+end
+
 group :test do
   gem "sqlite3"
 end

--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -9,7 +9,7 @@ describe Devise::Models::TwoFactorAuthenticatable, '#otp_code' do
   it "should return an error if no secret is set" do
     expect {
       subject
-    }.to raise_error
+    }.to raise_error Exception
   end
 
   context "secret is set" do

--- a/spec/rails_app/config/environments/test.rb
+++ b/spec/rails_app/config/environments/test.rb
@@ -9,7 +9,13 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_assets = true
+  if Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 2 ||
+    Rails::VERSION::MAJOR >= 5
+    config.serve_static_files = true
+  else
+    config.serve_static_assets = true
+  end
+
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching


### PR DESCRIPTION
Adds builds to the travisci matrix for Ruby 2.2 and Rails 4.2.4
Also fixes a couple of deprecation warnings that surface as part of
this change.