### PR TITLE
Move require rotp library to the file where it is used

### DIFF
--- a/lib/two_factor_authentication.rb
+++ b/lib/two_factor_authentication.rb
@@ -5,7 +5,6 @@ require "active_model"
 require "active_record"
 require "active_support/core_ext/class/attribute_accessors"
 require "cgi"
-require "rotp"
 
 module Devise
   mattr_accessor :max_login_attempts

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -1,4 +1,6 @@
 require 'two_factor_authentication/hooks/two_factor_authenticatable'
+require 'rotp'
+
 module Devise
   module Models
     module TwoFactorAuthenticatable


### PR DESCRIPTION
It is ok when I check it in development environment, but when I run some tests there are many errors ```uninitialized constant Devise::Models::TwoFactorAuthenticatable::InstanceMethodsOnActivation::ROTP```. I think it is because ```require 'rotp'``` is not in appropriate place.