### PR TITLE
Update bundler on Travis before installing gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"
 
+before_install:
+  - gem update bundler
+
 before_script:
   - bundle exec rake app:db:migrate
 


### PR DESCRIPTION
**Why**:
I noticed that recent builds started failing on Travis for no apparent reason. I then saw that Travis was using a different version of bundler compared to builds from 2 months ago. This version of bundler seems to be incompatible with certain versions of Ruby.

By making sure bundler is up to date, it allows Travis to install the gems on all the versions of Ruby that this repo supports.