### PR TITLE
Fix reset_otp_state specs

### DIFF
--- a/spec/features/two_factor_authenticatable_spec.rb
+++ b/spec/features/two_factor_authenticatable_spec.rb
@@ -148,6 +148,8 @@ feature "User of two factor authentication" do
   end
 
   describe 'signing in' do
+    let(:user) { create_user }
+
     scenario 'when UserOtpSender#reset_otp_state is defined' do
       stub_const 'UserOtpSender', Class.new
 
@@ -174,6 +176,8 @@ feature "User of two factor authentication" do
   end
 
   describe 'signing out' do
+    let(:user) { create_user }
+
     scenario 'when UserOtpSender#reset_otp_state is defined' do
       visit new_user_session_path
       complete_sign_in_form_for(user)

--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -224,7 +224,7 @@ describe Devise::Models::TwoFactorAuthenticatable do
 
         # This error is raised by the encryptor gem
         expect { instance.otp_secret_key = '2z6hxkdwi3uvrnpn' }.
-          to raise_error ArgumentError, 'must specify a :key'
+          to raise_error ArgumentError
       end
 
       it 'passes in the correct options to Encryptor' do


### PR DESCRIPTION
`user` was not defined in the specs.