### PR TITLE
Drop support for Ruby 1.9.3 & update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,25 @@
 language: ruby
 
 env:
-  - "RAILS_VERSION=3.2.0"
-  - "RAILS_VERSION=4.0.0"
-  - "RAILS_VERSION=4.1.1"
-  - "RAILS_VERSION=4.2.4"
+  - "RAILS_VERSION=3.2"
+  - "RAILS_VERSION=4.0"
+  - "RAILS_VERSION=4.1"
+  - "RAILS_VERSION=4.2"
   - "RAILS_VERSION=master"
 
 rvm:
-  - 1.9.3
   - 2.0
   - 2.1
-  - 2.2
+  - 2.2.2
 
 matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"
+  exclude:
+    - rvm: 2.0
+      env: RAILS_VERSION=master
+    - rvm: 2.1
+      env: RAILS_VERSION=master
 
 before_install:
   - gem update bundler

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Once that's done, run:
 
     bundle install
 
+Note that Ruby 2.0 or greater is required.
+
 ### Installation
 
 #### Automatic initial setup


### PR DESCRIPTION
**Why**:
The `encryptor` gem, which is used for the new OTP encryption feature,
requires Ruby 2.0 or later.

Also, Rails 5.0 requires Ruby 2.2.2 or greater, so we need to ignore
1.9.3, 2.0, and 2.1 when running RAILS_VERSION=master on Travis.