### PR TITLE
Fix class detection in reset_otp_state_for(user)

### DIFF
--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -22,11 +22,17 @@ end
 
 def reset_otp_state_for(user)
   klass_string = "#{user.class}OtpSender"
-  return unless Object.const_defined?(klass_string)
+  klass = class_from_string(klass_string)
 
-  klass = Object.const_get(klass_string)
+  return unless klass
 
   otp_sender = klass.new(user)
 
   otp_sender.reset_otp_state if otp_sender.respond_to?(:reset_otp_state)
+end
+
+def class_from_string(string)
+  string.constantize
+rescue NameError
+  false
 end

--- a/spec/rails_app/app/models/admin.rb
+++ b/spec/rails_app/app/models/admin.rb
@@ -1,0 +1,6 @@
+class Admin < ActiveRecord::Base
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+end

--- a/spec/rails_app/app/services/user_otp_sender.rb
+++ b/spec/rails_app/app/services/user_otp_sender.rb
@@ -1,0 +1,9 @@
+class UserOtpSender
+  def initialize(user)
+    @user = user
+  end
+
+  def reset_otp_state
+    @user.update_attributes(email: 'updated@example.com')
+  end
+end

--- a/spec/rails_app/config/initializers/devise.rb
+++ b/spec/rails_app/config/initializers/devise.rb
@@ -206,11 +206,11 @@ Devise.setup do |config|
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).
-  # config.default_scope = :user
+  config.default_scope = :user
 
   # Set this configuration to false if you want /users/sign_out to sign out
   # only the current scope. By default, Devise signs out all scopes.
-  # config.sign_out_all_scopes = true
+  config.sign_out_all_scopes = false
 
   # ==> Navigation configuration
   # Lists the formats that should be treated as navigational. Formats like

--- a/spec/rails_app/config/routes.rb
+++ b/spec/rails_app/config/routes.rb
@@ -1,4 +1,5 @@
 Dummy::Application.routes.draw do
+  devise_for :admins
   root to: "home#index"
 
   match "/dashboard", to: "home#dashboard", as: :dashboard, via: [:get]

--- a/spec/rails_app/db/migrate/20160209032439_devise_create_admins.rb
+++ b/spec/rails_app/db/migrate/20160209032439_devise_create_admins.rb
@@ -1,6 +1,6 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateAdmins < ActiveRecord::Migration
   def change
-    create_table(:users) do |t|
+    create_table(:admins) do |t|
       ## Database authenticatable
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
@@ -34,9 +34,9 @@ class DeviseCreateUsers < ActiveRecord::Migration
       t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
-    add_index :users, :reset_password_token, unique: true
-    # add_index :users, :confirmation_token,   unique: true
-    # add_index :users, :unlock_token,         unique: true
+    add_index :admins, :email,                unique: true
+    add_index :admins, :reset_password_token, unique: true
+    # add_index :admins, :confirmation_token,   unique: true
+    # add_index :admins, :unlock_token,         unique: true
   end
 end

--- a/spec/rails_app/db/schema.rb
+++ b/spec/rails_app/db/schema.rb
@@ -11,7 +11,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151228230340) do
+ActiveRecord::Schema.define(version: 20160209032439) do
+
+  create_table "admins", force: :cascade do |t|
+    t.string   "email",                  default: "", null: false
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer  "sign_in_count",          default: 0,  null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+  end
+
+  add_index "admins", ["email"], name: "index_admins_on_email", unique: true
+  add_index "admins", ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                                    default: "", null: false

--- a/spec/support/authenticated_model_helper.rb
+++ b/spec/support/authenticated_model_helper.rb
@@ -9,6 +9,10 @@ module AuthenticatedModelHelper
     User.create!(valid_attributes(attributes))
   end
 
+  def create_admin
+    Admin.create!(valid_attributes.except(:nickname))
+  end
+
   def valid_attributes(attributes={})
     {
       nickname: 'Marissa',


### PR DESCRIPTION
**Why**:
When looking up a class with `Object.const_defined?`, `false` will be returned the first time it is called, even when the class exists in the Rails app. I think this might be due to the way Rails loads classes.

**How**:
Use `ActiveSupport::Inflector#constantize`, which returns the class all the time when the class exists, and throws a `NameError` when it doesn't.

The only way I was able to properly test this was to create the `UserOtpSender` class as a real file in the test Rails app, and create a Devise Admin user to test the scenario where `AdminOtpSender` does not exist.

I verified that with the old code, `reset_otp_state` was not being called when it should be, and that the new code makes the tests pass.