### PR TITLE
Update spec to match change to rotp provisioning URI

### DIFF
--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -114,7 +114,7 @@ describe Devise::Models::TwoFactorAuthenticatable do
 
         expect(uri.scheme).to eq('otpauth')
         expect(uri.host).to eq('totp')
-        expect(uri.path).to eq('/houdini')
+        expect(uri.path).to eq('/Magic:houdini')
         expect(params['issuer'].shift).to eq('Magic')
         expect(params['secret'].shift).to match(/\w{16}/)
       end


### PR DESCRIPTION
The format changed to include the issuer in the URI
itself: https://github.com/mdp/rotp/commit/07825ecd