### PR TITLE
replaced flash :error key with :alert

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -52,7 +52,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   def after_two_factor_fail_for(resource)
     resource.second_factor_attempts_count += 1
     resource.save
-    flash.now[:error] = find_message(:attempt_failed)
+    set_flash_message :alert, find_message(:attempt_failed), now: true
 
     if resource.max_login_attempts?
       sign_out(resource)

--- a/spec/features/two_factor_authenticatable_spec.rb
+++ b/spec/features/two_factor_authenticatable_spec.rb
@@ -84,7 +84,7 @@ feature "User of two factor authentication" do
         fill_in "code", with: "incorrect#{rand(100)}"
         click_button "Submit"
 
-        within(".flash.error") do
+        within(".flash.alert") do
           expect(page).to have_content("Attempt failed")
         end
       end

--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -114,7 +114,7 @@ describe Devise::Models::TwoFactorAuthenticatable do
 
         expect(uri.scheme).to eq('otpauth')
         expect(uri.host).to eq('totp')
-        expect(uri.path).to eq('/houdini')
+        expect(uri.path).to eq('/Magic:houdini')
         expect(params['issuer'].shift).to eq('Magic')
         expect(params['secret'].shift).to match(/\w{16}/)
       end


### PR DESCRIPTION
Flash `:alert` key is more common usage than `:error` for setting errors in rails applications.
In `devise` gem also used `:alert` key ([proof](https://github.com/plataformatec/devise/search?utf8=%E2%9C%93&q=%3Aalert&type=Code))