### PR TITLE
Add locked_at timestamp when max attempts reached

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -55,6 +55,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     set_flash_message :alert, find_message(:attempt_failed), now: true
 
     if resource.max_login_attempts?
+      resource.locked_at = Time.now if resource.respond_to?(:locked_at=)
       sign_out(resource)
       render :max_login_attempts_reached
 


### PR DESCRIPTION
With this change, devise's time unlock mechanisms can be used. It's a more devise-friendly approach for issue #77 