### PR TITLE
Remove ruby 2.0 from travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,17 @@ env:
   - "RAILS_VERSION=master"
 
 rvm:
-  - 2.0
   - 2.1
-  - 2.2.2
+  - 2.2
+  - 2.3.1
 
 matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"
   exclude:
-    - rvm: 2.0
-      env: RAILS_VERSION=master
     - rvm: 2.1
+      env: RAILS_VERSION=master
+    - rvm: 2.2
       env: RAILS_VERSION=master
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once that's done, run:
 
     bundle install
 
-Note that Ruby 2.0 or greater is required.
+Note that Ruby 2.1 or greater is required.
 
 ### Installation
 


### PR DESCRIPTION
The latest version of Devise requires ruby >= 2.1.
This change removes 2.0 from the test matrix and adds 2.3.