### PR TITLE
Drop support for Rails 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 env:
-  - "RAILS_VERSION=3.2"
   - "RAILS_VERSION=4.0"
   - "RAILS_VERSION=4.1"
   - "RAILS_VERSION=4.2"

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -1,11 +1,6 @@
 class Devise::TwoFactorAuthenticationController < DeviseController
-  if Rails::VERSION::MAJOR >= 4
-    prepend_before_action :authenticate_scope!
-    before_action :prepare_and_validate, :handle_two_factor_authentication
-  else
-    prepend_before_filter :authenticate_scope!
-    before_filter :prepare_and_validate, :handle_two_factor_authentication
-  end
+  prepend_before_action :authenticate_scope!
+  before_action :prepare_and_validate, :handle_two_factor_authentication
 
   def show
   end

--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -4,11 +4,7 @@ module TwoFactorAuthentication
       extend ActiveSupport::Concern
 
       included do
-        if Rails::VERSION::MAJOR >= 4
-          before_action :handle_two_factor_authentication
-        else
-          before_filter :handle_two_factor_authentication
-        end
+        before_action :handle_two_factor_authentication
       end
 
       private

--- a/spec/rails_app/app/controllers/home_controller.rb
+++ b/spec/rails_app/app/controllers/home_controller.rb
@@ -1,9 +1,5 @@
 class HomeController < ApplicationController
-  if Rails::VERSION::MAJOR >= 4
-    before_action :authenticate_user!, only: :dashboard
-  else
-    before_filter :authenticate_user!, only: :dashboard
-  end
+  before_action :authenticate_user!, only: :dashboard
 
   def index
   end


### PR DESCRIPTION
**Why**: To be able to support Rails 5 without deprecation warnings,
we need to replace `before_filter` with `before_action`.
`before_action` is not supported in Rails 3.2, so we need to bump the
major version number since this will be a breaking change for people
who can't upgrade Rails.