### PR TITLE
Remove bundler-audit from .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,6 @@
 engines:
   brakeman:
     enabled: true
-  bundler-audit:
-    enabled: true
   duplication:
     enabled: true
     config:


### PR DESCRIPTION
**Why**: `bundler-audit` requires `Gemfile.lock` to be checked in, but it is gitignored on purpose in this repo. Enabling bundler-audit causes the Code Climate check to fail, but then seems to also prevent the rest of the engines from running.