### PR TITLE
Fix set_flash_message for :attempt_failed

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -47,7 +47,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   def after_two_factor_fail_for(resource)
     resource.second_factor_attempts_count += 1
     resource.save
-    set_flash_message :alert, find_message(:attempt_failed), now: true
+    set_flash_message :alert, :attempt_failed, now: true
 
     if resource.max_login_attempts?
       sign_out(resource)


### PR DESCRIPTION
Hello i found a little glitch in the `after_two_factor_fail_for`. The `set_flash_message` method call `find_message(:attempt_failed)` as second parameter but the method `set_flash_message` from Devise already does a find_message.

```ruby
def set_flash_message(key, kind, options = {})
    message = find_message(kind, options)
    if options[:now]
      flash.now[key] = message if message.present?
    else
      flash[key] = message if message.present?
    end
 end
```

Which result in `devise.two_factor_authentication.user.Attempt failed.`
But we want: `devise.two_factor_authentication.user.attempt_failed`

I'm using 
- Devise: 4.2.0
- two_factor_authentication: master