### PR TITLE
Updates deprecated Devise methods

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -33,7 +33,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     end
 
     warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
-    sign_in resource_name, resource, :bypass => true
+    bypass_sign_in(resource, scope: resource_name)
     set_flash_message :notice, :success
     resource.update_attribute(:second_factor_attempts_count, 0)
 

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -7,7 +7,7 @@ module ControllerHelper
 end
 
 RSpec.configure do |config|
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include ControllerHelper, type: :controller
 
   config.before(:example, type: :controller) do


### PR DESCRIPTION
Squashes two Devise deprecation warnings:
```
DEPRECATION WARNING: [Devise] bypass option is deprecated and it will be removed in future version of Devise.
Please use bypass_sign_in method instead.
Example:

  bypass_sign_in(user)
```

```
DEPRECATION WARNING:           [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
          For controller tests, please include `Devise::Test::ControllerHelpers` instead.
```