### PR TITLE
Adds options hash to method call on resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ The `otp_secret_encryption_key` must be a random key that is not stored in the
 DB, and is not checked in to your repo. It is recommended to store it in an
 environment variable, and you can generate it with `bundle exec rake secret`.
 
-Override the method in your model in order to send direct OTP codes. This is
+Override this method in your model in order to send direct OTP codes. This is
 automatically called when a user logs in unless they have TOTP enabled (see
 below):
 
 ```ruby
-def send_two_factor_authentication_code(code)
+def send_two_factor_authentication_code(code, options)
   # Send code via SMS, etc.
 end
 ```

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -55,10 +55,15 @@ module Devise
 
         def send_new_otp(options = {})
           create_direct_otp options
-          send_two_factor_authentication_code(direct_otp)
+
+          if instance_accepts_opts?
+            send_two_factor_authentication_code(direct_otp, options)
+          else
+            send_two_factor_authentication_code(direct_otp)
+          end
         end
 
-        def send_two_factor_authentication_code(code)
+        def send_two_factor_authentication_code(*args)
           raise NotImplementedError.new("No default implementation - please define in your class.")
         end
 
@@ -105,6 +110,11 @@ module Devise
 
         def clear_direct_otp
           update_attributes(direct_otp: nil, direct_otp_sent_at: nil)
+        end
+
+        def instance_accepts_opts?
+          arity = self.class.instance_method(:send_two_factor_authentication_code).arity
+          arity.abs == 2 || arity == -1
         end
       end
 

--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -112,6 +112,64 @@ describe Devise::Models::TwoFactorAuthenticatable do
     end
   end
 
+  describe '#send_new_otp' do
+    let(:instance) { TempGuestUser.new }
+
+    context 'when :send_two_factor_authentication_code accepts options' do
+      before do
+        class TempGuestUser < GuestUser
+          def send_two_factor_authentication_code(code, opts); end
+        end
+      end
+
+      it 'messages options to :send_two_factor_authentication_code' do
+        instance.update_attributes(direct_otp: '999999' )
+        allow(instance).to receive(:create_direct_otp).and_return(nil)
+
+        expect(instance).to receive(:send_two_factor_authentication_code).with(
+          '999999', { merp: :foo })
+
+        instance.send_new_otp({ merp: :foo })
+      end
+    end
+
+    context 'when :send_two_factor_authentication_code only accepts code' do
+      before do
+        class TempGuestUser < GuestUser
+          def send_two_factor_authentication_code(code); end
+        end
+      end
+
+      it 'messages only code to :send_two_factor_authentication_code' do
+        instance.update_attributes(direct_otp: '888888' )
+        allow(instance).to receive(:create_direct_otp).and_return(nil)
+
+        expect(instance).to receive(:send_two_factor_authentication_code).with(
+          '888888')
+
+        instance.send_new_otp({ derp: :moo })
+      end
+    end
+
+    context 'when :send_two_factor_authentication_code accepts any args' do
+      before do
+        class TempGuestUser < GuestUser
+          def send_two_factor_authentication_code(*args); end
+        end
+      end
+
+      it 'messages options to :send_two_factor_authentication_code' do
+        instance.update_attributes(direct_otp: '999999' )
+        allow(instance).to receive(:create_direct_otp).and_return(nil)
+
+        expect(instance).to receive(:send_two_factor_authentication_code).with(
+          '999999', { herp: :aderp })
+
+        instance.send_new_otp({ herp: :aderp })
+      end
+    end
+  end
+
   describe '#provisioning_uri' do
 
     shared_examples 'provisioning_uri' do |instance|


### PR DESCRIPTION
**Why**
The only way to configure OTP delivery options is by managing state with
attributes. This adds more flexibility in implementating the
:send_two_factor_authentication_code method.

**How**
Have the gem pass the options hash back to the send_two_factor_authentication_code
method on the resource. This permits at run-time options to reside with the send_new_otp
call. This also maintains compatibility with existing implementations where
:send_two_factor_authentication_code only accepts one argument.