### PR TITLE
Custom resource id field

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ config.direct_otp_valid_for = 5.minutes  # Time before direct OTP becomes invali
 config.direct_otp_length = 6  # Direct OTP code length
 config.remember_otp_session_for_seconds = 30.days  # Time before browser has to perform 2fA again. Default is 0.
 config.otp_secret_encryption_key = ENV['OTP_SECRET_ENCRYPTION_KEY']
+config.second_factor_resource_id = 'id' # Field or method name used to set value for 2fA remember cookie
 ```
 The `otp_secret_encryption_key` must be a random key that is not stored in the
 DB, and is not checked in to your repo. It is recommended to store it in an

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -23,7 +23,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   private
 
   def after_two_factor_success_for(resource)
-    set_remember_tfa_cookie(resource)
+    set_remember_two_factor_cookie(resource)
 
     warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
     bypass_sign_in(resource, scope: resource_name)
@@ -33,7 +33,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     redirect_to after_two_factor_success_path_for(resource)
   end
 
-  def set_remember_tfa_cookie(resource)
+  def set_remember_two_factor_cookie(resource)
     expires_seconds = resource.class.remember_otp_session_for_seconds
 
     if expires_seconds && expires_seconds > 0

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -23,14 +23,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   private
 
   def after_two_factor_success_for(resource)
-    expires_seconds = resource.class.remember_otp_session_for_seconds
-
-    if expires_seconds && expires_seconds > 0
-      cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {
-          value: "#{resource.class}-#{resource.id}",
-          expires: expires_seconds.from_now
-      }
-    end
+    set_remember_tfa_cookie(resource)
 
     warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
     bypass_sign_in(resource, scope: resource_name)
@@ -38,6 +31,17 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     resource.update_attribute(:second_factor_attempts_count, 0)
 
     redirect_to after_two_factor_success_path_for(resource)
+  end
+
+  def set_remember_tfa_cookie(resource)
+    expires_seconds = resource.class.remember_otp_session_for_seconds
+
+    if expires_seconds && expires_seconds > 0
+      cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {
+          value: "#{resource.class}-#{resource.public_send(Devise.second_factor_resource_id)}",
+          expires: expires_seconds.from_now
+      }
+    end
   end
 
   def after_two_factor_success_path_for(resource)

--- a/lib/two_factor_authentication.rb
+++ b/lib/two_factor_authentication.rb
@@ -27,6 +27,9 @@ module Devise
 
   mattr_accessor :otp_secret_encryption_key
   @@otp_secret_encryption_key = ''
+
+  mattr_accessor :second_factor_resource_id
+  @@second_factor_resource_id = 'id'
 end
 
 module TwoFactorAuthentication

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -1,6 +1,6 @@
 Warden::Manager.after_authentication do |user, auth, options|
   if auth.env["action_dispatch.cookies"]
-    expected_cookie_value = "#{user.class}-#{user.id}"
+    expected_cookie_value = "#{user.class}-#{user.public_send(Devise.second_factor_resource_id)}",
     actual_cookie_value = auth.env["action_dispatch.cookies"].signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME]
     bypass_by_cookie = actual_cookie_value == expected_cookie_value
   end


### PR DESCRIPTION
@Houdini One of my colleagues reached out to you recently with a security issue that was reported on our platform. Mainly - the same remember 2fa cookie value is used throughout multiple sign ins. So here's a quick attempt to resolve the issue when needed by using the custom method to set value of the cookie.

I also noticed that the exact cookie value is not being tested anywhere in any way, and I'd like very much to change that, but am not sure how exactly tackle this. Could you give me some pointers perhaps?

Or if you are already working on a patch like you mentioned in an email for my colleague, when you expect this to be merged?