### PR TITLE
Allow default view to work for resources other than User

### DIFF
--- a/app/views/devise/two_factor_authentication/show.html.erb
+++ b/app/views/devise/two_factor_authentication/show.html.erb
@@ -11,9 +11,10 @@
   <%= submit_tag "Submit" %>
 <% end %>
 
+<% resend_code_url = url_for(action: :resend_code) %>
 <% if resource.direct_otp %>
-<%= link_to "Resend Code", resend_code_user_two_factor_authentication_path, action: :get %>
+<%= link_to "Resend Code", resend_code_url, action: :get %>
 <% else %>
-<%= link_to "Send me a code instead", resend_code_user_two_factor_authentication_path, action: :get %>
+<%= link_to "Send me a code instead", resend_code_url, action: :get %>
 <% end %>
-<%= link_to "Sign out", destroy_user_session_path, :method => :delete %>
+<%= link_to "Sign out", [:destroy, resource_name, :session], :method => :delete %>


### PR DESCRIPTION
Previously, several lines in the default show.html.erb assumed that the
resource being authenticated was called 'User'. This commit genericizes these
methods so they'll work for other resource names.

Please let me know what you think! The tests which are failing in this build were also failing in the [master build](https://github.com/Houdini/two_factor_authentication/commit/40fb11b069dd77603e04f6d6d4a17a709585ad35) at the time I forked, so as far as I know they aren't caused by any changes in this pull request.