### PR TITLE
Fix test and deprecations

### DIFF
--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -162,7 +162,7 @@ module Devise
           iv = encrypted_otp_secret_key_iv
 
           if iv.nil?
-            algo = OpenSSL::Cipher::Cipher.new(algorithm)
+            algo = OpenSSL::Cipher.new(algorithm)
             iv = [algo.random_iv].pack('m')
             self.encrypted_otp_secret_key_iv = iv
           end

--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -289,7 +289,8 @@ describe Devise::Models::TwoFactorAuthenticatable do
           value: 'testing',
           key: Devise.otp_secret_encryption_key,
           iv: iv.unpack('m').first,
-          salt: salt.unpack('m').first
+          salt: salt.unpack('m').first,
+          algorithm: 'aes-256-cbc'
         )
 
         expect(instance.encrypted_otp_secret_key).to eq [encrypted].pack('m')


### PR DESCRIPTION
Removes a deprecation warning from OpenSSL, and updates a test to use the new encryption algorithm from #111.