### PR TITLE
Check and use if newer bypass_sign_in method exists in devise

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -30,7 +30,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
     # For compatability with devise versions below v4.2.0
     # https://github.com/plataformatec/devise/commit/2044fffa25d781fcbaf090e7728b48b65c854ccb
-    if Devise::VERSION.to_f >= 4.2
+    if respond_to?(:bypass_sign_in)
       bypass_sign_in(resource, scope: resource_name)
     else
       sign_in(resource_name, resource, bypass: true)


### PR DESCRIPTION
Currently them gem produces an exception in Rails 5 using the newest devise gem saying `Devise::VERSION` is not set. However, using `respond_to?` works like a charm. Checking a method exists could also be a more preferable approach to ensure that we are using a newer devise gem.
