### PR TITLE
Added check for cookie expiration at DB level

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -45,7 +45,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     expires_seconds = resource.class.remember_otp_session_for_seconds
 
     if expires_seconds && expires_seconds > 0
-      resource.update_attribute(:expire_token, expires_seconds.from_now)
+      resource.update_attribute(:cookie_expire, expires_seconds.from_now)
       cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {
           value: "#{resource.class}-#{resource.public_send(Devise.second_factor_resource_id)}",
           expires: expires_seconds.from_now

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -45,6 +45,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     expires_seconds = resource.class.remember_otp_session_for_seconds
 
     if expires_seconds && expires_seconds > 0
+      resource.update_attribute(:expire_token, expires_seconds.from_now)
       cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {
           value: "#{resource.class}-#{resource.public_send(Devise.second_factor_resource_id)}",
           expires: expires_seconds.from_now

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -7,6 +7,7 @@ class TwoFactorAuthenticationAddTo<%= table_name.camelize %> < ActiveRecord::Mig
     add_column :<%= table_name %>, :direct_otp, :string
     add_column :<%= table_name %>, :direct_otp_sent_at, :datetime
     add_column :<%= table_name %>, :totp_timestamp, :timestamp
+    add_column :<%= table_name %>, :cookie_expire, :timestamp
 
     add_index :<%= table_name %>, :encrypted_otp_secret_key, unique: true
   end

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -2,7 +2,7 @@ Warden::Manager.after_authentication do |user, auth, options|
   if auth.env["action_dispatch.cookies"]
     expected_cookie_value = "#{user.class}-#{user.public_send(Devise.second_factor_resource_id)}"
     actual_cookie_value = auth.env["action_dispatch.cookies"].signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME]
-    bypass_by_cookie = actual_cookie_value == expected_cookie_value
+    bypass_by_cookie = (actual_cookie_value == expected_cookie_value) && user.expire_token > Time.now
   end
 
   if user.respond_to?(:need_two_factor_authentication?) && !bypass_by_cookie

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -2,8 +2,9 @@ Warden::Manager.after_authentication do |user, auth, options|
   if auth.env["action_dispatch.cookies"]
     expected_cookie_value = "#{user.class}-#{user.public_send(Devise.second_factor_resource_id)}"
     actual_cookie_value = auth.env["action_dispatch.cookies"].signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME]
-    bypass_by_cookie = (actual_cookie_value == expected_cookie_value) && user.expire_token > Time.now
+    bypass_by_cookie = (actual_cookie_value == expected_cookie_value) && (user.cookie_expire.blank? || (user.cookie_expire > Time.now))
   end
+
 
   if user.respond_to?(:need_two_factor_authentication?) && !bypass_by_cookie
     if auth.session(options[:scope])[TwoFactorAuthentication::NEED_AUTHENTICATION] = user.need_two_factor_authentication?(auth.request)

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -16,7 +16,7 @@ module Devise
         ::Devise::Models.config(
           self, :max_login_attempts, :allowed_otp_drift_seconds, :otp_length,
           :remember_otp_session_for_seconds, :otp_secret_encryption_key,
-          :direct_otp_length, :direct_otp_valid_for, :totp_timestamp)
+          :direct_otp_length, :direct_otp_valid_for, :totp_timestamp, :cookie_expire)
       end
 
       module InstanceMethodsOnActivation

--- a/lib/two_factor_authentication/schema.rb
+++ b/lib/two_factor_authentication/schema.rb
@@ -27,5 +27,9 @@ module TwoFactorAuthentication
     def totp_timestamp
       apply_devise_schema :totp_timestamp, Timestamp
     end
+
+    def cookie_expire
+      apply_devise_schema :cookie_expire, Timestamp
+    end
   end
 end

--- a/spec/rails_app/app/models/encrypted_user.rb
+++ b/spec/rails_app/app/models/encrypted_user.rb
@@ -9,7 +9,8 @@ class EncryptedUser
                 :encrypted_otp_secret_key_salt,
                 :email,
                 :second_factor_attempts_count,
-                :totp_timestamp
+                :totp_timestamp,
+                :cookie_expire
 
   has_one_time_password(encrypted: true)
 end

--- a/spec/rails_app/app/models/guest_user.rb
+++ b/spec/rails_app/app/models/guest_user.rb
@@ -5,7 +5,7 @@ class GuestUser
 
   define_model_callbacks :create
   attr_accessor :direct_otp, :direct_otp_sent_at, :otp_secret_key, :email,
-    :second_factor_attempts_count, :totp_timestamp
+    :second_factor_attempts_count, :totp_timestamp,:cookie_expire
 
   def update_attributes(attrs)
     attrs.each do |key, value|

--- a/spec/support/authenticated_model_helper.rb
+++ b/spec/support/authenticated_model_helper.rb
@@ -50,6 +50,7 @@ module AuthenticatedModelHelper
           t.string    'direct_otp'
           t.datetime  'direct_otp_sent_at'
           t.timestamp 'totp_timestamp'
+          t.timestamp 'cookie_expire'
         end
       end
     end


### PR DESCRIPTION
This change prevents the user from being able to bypass 2FA by changing the expiration of the cookie manually by adding a timestamp for cookie expiration.

One potential issue is if the configuration option for cookie expiration is changed it won't take effect until the next time 2FA is requested for that specific user. 