### PR TITLE
Make it work with rails 3

### DIFF
--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -4,7 +4,7 @@ module TwoFactorAuthentication
       extend ActiveSupport::Concern
 
       included do
-        before_action :handle_two_factor_authentication
+        Rails.version.to_i > 3 ? before_action(:handle_two_factor_authentication) : before_filter(:handle_two_factor_authentication) 
       end
 
       private


### PR DESCRIPTION
On Rails ~>3.1 current code throws `undefined method before_action`. This small fix allows this gem to work with rails3.