### PR TITLE
Make totp_timestamp column an integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ devise :database_authenticatable, :registerable, :recoverable, :rememberable,
 Then create your migration file using the Rails generator, such as:
 
 ```
-rails g migration AddTwoFactorFieldsToUsers second_factor_attempts_count:integer encrypted_otp_secret_key:string:index encrypted_otp_secret_key_iv:string encrypted_otp_secret_key_salt:string direct_otp:string direct_otp_sent_at:datetime totp_timestamp:timestamp
+rails g migration AddTwoFactorFieldsToUsers second_factor_attempts_count:integer encrypted_otp_secret_key:string:index encrypted_otp_secret_key_iv:string encrypted_otp_secret_key_salt:string direct_otp:string direct_otp_sent_at:datetime totp_timestamp:integer
 ```
 
 Open your migration file (it will be in the `db/migrate` directory and will be
@@ -174,7 +174,7 @@ The following database fields are new in version 2.
 
 To add them, generate a migration such as:
 
-    $ rails g migration AddTwoFactorFieldsToUsers direct_otp:string direct_otp_sent_at:datetime totp_timestamp:timestamp
+    $ rails g migration AddTwoFactorFieldsToUsers direct_otp:string direct_otp_sent_at:datetime totp_timestamp:integer
 
 The `otp_secret_key` is only required for users who use TOTP (Google Authenticator) codes,
 so unless it has been shared with the user it should be set to `nil`.  The

--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -6,7 +6,7 @@ class TwoFactorAuthenticationAddTo<%= table_name.camelize %> < ActiveRecord::Mig
     add_column :<%= table_name %>, :encrypted_otp_secret_key_salt, :string
     add_column :<%= table_name %>, :direct_otp, :string
     add_column :<%= table_name %>, :direct_otp_sent_at, :datetime
-    add_column :<%= table_name %>, :totp_timestamp, :timestamp
+    add_column :<%= table_name %>, :totp_timestamp, :integer
 
     add_index :<%= table_name %>, :encrypted_otp_secret_key, unique: true
   end

--- a/lib/two_factor_authentication/schema.rb
+++ b/lib/two_factor_authentication/schema.rb
@@ -25,7 +25,7 @@ module TwoFactorAuthentication
     end
 
     def totp_timestamp
-      apply_devise_schema :totp_timestamp, Timestamp
+      apply_devise_schema :totp_timestamp, Integer
     end
   end
 end


### PR DESCRIPTION
The ROTP gem expects the prior timestamp in `verify_with_drift_and_prior` to be an integer. Moreover, when `verify_with_drift_and_prior` returns it returns an integer.

We noticed a bug where the `totp_timestamp` column was always nil. The reason for this was that the database had a timestamp column and when this gem was attempting to assign `totp_timestamp` to an integer, it was actually set to nil.

This commit changes the column to an integer instead of a timestamp to avoid the problem described above.

Another potential solution is to change the result of `verify_with_drift_and_prior` to a datetime before saving, and then change the value of `totp_timestamp` to an integer before calling `verify_with_drift_and_prior`.

I went with the solution I did instead b/c it looked like the path of least resistance, but am happy to modify my PR to leave the column as a timestamp and handle moving between integers and dates in the `authenticate_totp` method.