### PR TITLE
Delegate logic of whether to send_new_otp to user#send_new_otp_after_login? method

### DIFF
--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -7,7 +7,7 @@ Warden::Manager.after_authentication do |user, auth, options|
 
   if user.respond_to?(:need_two_factor_authentication?) && !bypass_by_cookie
     if auth.session(options[:scope])[TwoFactorAuthentication::NEED_AUTHENTICATION] = user.need_two_factor_authentication?(auth.request)
-      user.send_new_otp unless user.totp_enabled?
+      user.send_new_otp if user.send_new_otp_after_login?
     end
   end
 end

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -62,6 +62,10 @@ module Devise
           send_two_factor_authentication_code(direct_otp)
         end
 
+        def send_new_otp_after_login?
+          !totp_enabled?
+        end
+
         def send_two_factor_authentication_code(code)
           raise NotImplementedError.new("No default implementation - please define in your class.")
         end


### PR DESCRIPTION
## What does it do?

- Delegates logic of whether to call `user.send_new_otp` to the `user#send_new_otp_after_login?` method
- Instead of keeping this logic nested in the Warden hook, call a method on the user object to determine if a new OTP code should be delivered.

## Communication

We realized the need for this upon upgrading from v1 to v2. Our application needs to make a slightly different decision of when the OTP code is delivered via SMS to the user. This is just a small refactor to enable an application to more easily override this business logic by adding a custom `send_new_otp_after_login?` method to the `User` model.
 
/cc @Houdini @mattmueller @rossta 