### PR TITLE
Improve Travis build matrix; Better Rails 5 coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ before_install:
   - gem update bundler
 
 before_script:
-  - bundle exec rake app:db:migrate
+  - bundle exec rake app:db:setup
 
 script: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
   - "RAILS_VERSION=master"
 
 rvm:
-  - 2.2
   - 2.3.6
   - 2.4.3
   - 2.5.0
@@ -15,9 +14,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: "RAILS_VERSION=master"
-  exclude:
+  include:
     - rvm: 2.2
-      env: RAILS_VERSION=master
+      env: RAILS_VERSION=4.2
 
 before_install:
   - gem update bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 language: ruby
 
 env:
-  - "RAILS_VERSION=4.0"
-  - "RAILS_VERSION=4.1"
   - "RAILS_VERSION=4.2"
+  - "RAILS_VERSION=5.1"
   - "RAILS_VERSION=master"
 
 rvm:
-  - 2.1
   - 2.2
-  - 2.3.1
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
 
 matrix:
+  fast_finish: true
   allow_failures:
     - env: "RAILS_VERSION=master"
   exclude:
-    - rvm: 2.1
-      env: RAILS_VERSION=master
     - rvm: 2.2
       env: RAILS_VERSION=master
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ rails = case rails_version
         when "master"
           {github: "rails/rails"}
         when "default"
-          "~> 4.1"
+          "~> 5.1"
         else
           "~> #{rails_version}"
         end

--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,4 @@ end
 group :test do
   gem 'rack_session_access'
   gem 'ammeter'
-  gem 'pry'
 end

--- a/spec/controllers/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication_controller_spec.rb
@@ -2,6 +2,14 @@ require 'spec_helper'
 
 describe Devise::TwoFactorAuthenticationController, type: :controller do
   describe 'is_fully_authenticated? helper' do
+    def post_code(code)
+      if Rails::VERSION::MAJOR >= 5
+        post :update, params: { code: code }
+      else
+        post :update, code: code
+      end
+    end
+
     before do
       sign_in
     end
@@ -9,7 +17,7 @@ describe Devise::TwoFactorAuthenticationController, type: :controller do
     context 'after user enters valid OTP code' do
       it 'returns true' do
         controller.current_user.send_new_otp
-        post :update, code: controller.current_user.direct_otp
+        post_code controller.current_user.direct_otp
         expect(subject.is_fully_authenticated?).to eq true
       end
     end
@@ -24,7 +32,7 @@ describe Devise::TwoFactorAuthenticationController, type: :controller do
 
     context 'when user enters an invalid OTP' do
       it 'returns false' do
-        post :update, code: '12345'
+        post_code '12345'
 
         expect(subject.is_fully_authenticated?).to eq false
       end

--- a/spec/rails_app/db/migrate/20140403184646_devise_create_users.rb
+++ b/spec/rails_app/db/migrate/20140403184646_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/spec/rails_app/db/migrate/20140407172619_two_factor_authentication_add_to_users.rb
+++ b/spec/rails_app/db/migrate/20140407172619_two_factor_authentication_add_to_users.rb
@@ -1,4 +1,4 @@
-class TwoFactorAuthenticationAddToUsers < ActiveRecord::Migration
+class TwoFactorAuthenticationAddToUsers < ActiveRecord::Migration[4.2]
   def up
     change_table :users do |t|
       t.string   :otp_secret_key

--- a/spec/rails_app/db/migrate/20140407215513_add_nickanme_to_users.rb
+++ b/spec/rails_app/db/migrate/20140407215513_add_nickanme_to_users.rb
@@ -1,4 +1,4 @@
-class AddNickanmeToUsers < ActiveRecord::Migration
+class AddNickanmeToUsers < ActiveRecord::Migration[4.2]
   def change
     change_table :users do |t|
       t.column :nickname, :string, limit: 64

--- a/spec/rails_app/db/migrate/20151224171231_add_encrypted_columns_to_user.rb
+++ b/spec/rails_app/db/migrate/20151224171231_add_encrypted_columns_to_user.rb
@@ -1,4 +1,4 @@
-class AddEncryptedColumnsToUser < ActiveRecord::Migration
+class AddEncryptedColumnsToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :encrypted_otp_secret_key, :string
     add_column :users, :encrypted_otp_secret_key_iv, :string

--- a/spec/rails_app/db/migrate/20151224180310_populate_otp_column.rb
+++ b/spec/rails_app/db/migrate/20151224180310_populate_otp_column.rb
@@ -1,4 +1,4 @@
-class PopulateOtpColumn < ActiveRecord::Migration
+class PopulateOtpColumn < ActiveRecord::Migration[4.2]
   def up
     User.reset_column_information
 

--- a/spec/rails_app/db/migrate/20151228230340_remove_otp_secret_key_from_user.rb
+++ b/spec/rails_app/db/migrate/20151228230340_remove_otp_secret_key_from_user.rb
@@ -1,4 +1,4 @@
-class RemoveOtpSecretKeyFromUser < ActiveRecord::Migration
+class RemoveOtpSecretKeyFromUser < ActiveRecord::Migration[4.2]
   def change
     remove_column :users, :otp_secret_key, :string
   end

--- a/spec/rails_app/db/migrate/20160209032439_devise_create_admins.rb
+++ b/spec/rails_app/db/migrate/20160209032439_devise_create_admins.rb
@@ -1,4 +1,4 @@
-class DeviseCreateAdmins < ActiveRecord::Migration
+class DeviseCreateAdmins < ActiveRecord::Migration[4.2]
   def change
     create_table(:admins) do |t|
       ## Database authenticatable

--- a/spec/rails_app/db/schema.rb
+++ b/spec/rails_app/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -14,45 +13,43 @@
 ActiveRecord::Schema.define(version: 20160209032439) do
 
   create_table "admins", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
-
-  add_index "admins", ["email"], name: "index_admins_on_email", unique: true
-  add_index "admins", ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                                    default: "", null: false
-    t.string   "encrypted_password",                       default: "", null: false
-    t.string   "reset_password_token"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                            default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.datetime "created_at",                                            null: false
-    t.datetime "updated_at",                                            null: false
-    t.integer  "second_factor_attempts_count",             default: 0
-    t.string   "nickname",                      limit: 64
-    t.string   "encrypted_otp_secret_key"
-    t.string   "encrypted_otp_secret_key_iv"
-    t.string   "encrypted_otp_secret_key_salt"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "second_factor_attempts_count", default: 0
+    t.string "nickname", limit: 64
+    t.string "encrypted_otp_secret_key"
+    t.string "encrypted_otp_secret_key_iv"
+    t.string "encrypted_otp_secret_key_salt"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["encrypted_otp_secret_key"], name: "index_users_on_encrypted_otp_secret_key", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
 end

--- a/spec/support/authenticated_model_helper.rb
+++ b/spec/support/authenticated_model_helper.rb
@@ -29,7 +29,7 @@ module AuthenticatedModelHelper
   end
 
   def create_table_for_nonencrypted_user
-    silence_stream(STDOUT) do
+    ActiveRecord::Migration.suppress_messages do
       ActiveRecord::Schema.define(version: 1) do
         create_table 'users', force: :cascade do |t|
           t.string    'email', default: '', null: false

--- a/two_factor_authentication.gemspec
+++ b/two_factor_authentication.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec-rails', '>= 3.0.1'
-  s.add_development_dependency 'capybara', '2.4.1'
+  s.add_development_dependency 'capybara', '~> 2.5'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'timecop'
 end


### PR DESCRIPTION
## What does it do?

- Adds Rails 5 support to specs
- Upgrades capybara dependency for Rails 5 support
- Updates travis build matrix to only run against supported versions of Rails and Ruby
- Enables `fast_finish` in build matrix
- Removes duplicate pry entry in `Gemfile`
- Makes Rails 5.1 the _"default"_ version of in Gemfile
- Normalizes the migration syntax between Rails 4 and Rails 5

## Communication

**Let me know if you need help maintaining this gem.**

/cc @Houdini @mattmueller @rossta 