### PR TITLE
Replace `render :nothing` with `head`

### DIFF
--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -24,7 +24,7 @@ module TwoFactorAuthentication
           session["#{scope}_return_to"] = request.original_fullpath if request.get?
           redirect_to two_factor_authentication_path_for(scope)
         else
-          render nothing: true, status: :unauthorized
+          head :unauthorized
         end
       end
 


### PR DESCRIPTION
fixes Houdini/two_factor_authentication#147