### PR TITLE
Fix integer to seconds in remember_otp_session_for_seconds

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -47,7 +47,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     if expires_seconds && expires_seconds > 0
       cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {
           value: "#{resource.class}-#{resource.public_send(Devise.second_factor_resource_id)}",
-          expires: expires_seconds.from_now
+          expires: expires_seconds.seconds.from_now
       }
     end
   end


### PR DESCRIPTION
The `remember_otp_session_for_seconds` is usually an integer representing seconds, but the expiration calls `from_now` which is not available on integer.

Convert it to seconds.

Scenarios:

- remember_otp_session_for_seconds = 0 - works (will call `0.seconds.from_now`)
- remember_otp_session_for_seconds = 3600 - works  (will call `3600.seconds.from_now`)
- remember_otp_session_for_seconds = 3600.seconds - works (will call `3600.seconds.seconds.from_now`)

Additionally any valid duration that responds to `seconds` can be provided.