### PR TITLE
Load ActiveRecord functionality only if ActiveRecord itself is loaded

### DIFF
--- a/lib/two_factor_authentication.rb
+++ b/lib/two_factor_authentication.rb
@@ -2,7 +2,6 @@ require 'two_factor_authentication/version'
 require 'devise'
 require 'active_support/concern'
 require "active_model"
-require "active_record"
 require "active_support/core_ext/class/attribute_accessors"
 require "cgi"
 
@@ -47,7 +46,7 @@ end
 
 Devise.add_module :two_factor_authenticatable, :model => 'two_factor_authentication/models/two_factor_authenticatable', :controller => :two_factor_authentication, :route => :two_factor_authentication
 
-require 'two_factor_authentication/orm/active_record'
+require 'two_factor_authentication/orm/active_record' if defined?(ActiveRecord::Base)
 require 'two_factor_authentication/routes'
 require 'two_factor_authentication/models/two_factor_authenticatable'
 require 'two_factor_authentication/rails'

--- a/lib/two_factor_authentication/orm/active_record.rb
+++ b/lib/two_factor_authentication/orm/active_record.rb
@@ -1,3 +1,5 @@
+require "active_record"
+
 module TwoFactorAuthentication
   module Orm
     module ActiveRecord


### PR DESCRIPTION
This PR allows working with mongoid when ActiveRecord is not available or not required.