### PR TITLE
Subdomain aware redirects and scope based cookie names

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -27,7 +27,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   def after_two_factor_success_for(resource)
     set_remember_two_factor_cookie(resource)
 
-    warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
+    warden.session(resource_name)[TwoFactorAuthentication::name_for(:need_authentication, resource_name)] = false
     # For compatability with devise versions below v4.2.0
     # https://github.com/plataformatec/devise/commit/2044fffa25d781fcbaf090e7728b48b65c854ccb
     if respond_to?(:bypass_sign_in)
@@ -45,7 +45,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     expires_seconds = resource.class.remember_otp_session_for_seconds
 
     if expires_seconds && expires_seconds > 0
-      cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {
+      cookies.signed[TwoFactorAuthentication::name_for(:remember_tfa_cookie_name, Devise::Mapping.find_scope!(resource))] = {
           value: "#{resource.class}-#{resource.public_send(Devise.second_factor_resource_id)}",
           expires: expires_seconds.seconds.from_now
       }

--- a/lib/two_factor_authentication.rb
+++ b/lib/two_factor_authentication.rb
@@ -38,6 +38,10 @@ module TwoFactorAuthentication
   NEED_AUTHENTICATION = 'need_two_factor_authentication'
   REMEMBER_TFA_COOKIE_NAME = "remember_tfa"
 
+  def self.name_for(sym, scope)
+    "#{self.const_get(sym.upcase.to_s)}_#{scope.to_s}"
+  end
+
   autoload :Schema, 'two_factor_authentication/schema'
   module Controllers
     autoload :Helpers, 'two_factor_authentication/controllers/helpers'

--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -14,7 +14,7 @@ module TwoFactorAuthentication
           Devise.mappings.keys.flatten.any? do |scope|
             if signed_in?(scope) and warden.session(scope)[TwoFactorAuthentication::name_for(:need_authentication,
                                                                                              scope)] and
-                public_send("current_#{scope}").class.subdomain_in_scope?
+                public_send("current_#{scope}").class.subdomain_in_scope?(request.subdomain)
               handle_failed_second_factor(scope)
             end
           end

--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -23,9 +23,11 @@ module TwoFactorAuthentication
       def handle_failed_second_factor(scope)
         if request.format.present? and request.format.html?
           session["#{scope}_return_to"] = request.original_fullpath if request.get?
-
-          scoped_to_subdomain = public_send("current_#{scope}")&.scoped_to_subdomain
-          return if scoped_to_subdomain && request.subdomain != scoped_to_subdomain
+          begin
+            scoped_to_subdomain = public_send("current_#{scope}")&.scoped_to_subdomain
+            return if scoped_to_subdomain && request.subdomain != scoped_to_subdomain
+          rescue => e
+          end
           redirect_to two_factor_authentication_path_for(scope)
         else
           head :unauthorized

--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -24,8 +24,9 @@ module TwoFactorAuthentication
         if request.format.present? and request.format.html?
           session["#{scope}_return_to"] = request.original_fullpath if request.get?
           begin
-            scoped_to_subdomain = public_send("current_#{scope}")&.scoped_to_subdomain
-            return if scoped_to_subdomain && request.subdomain != scoped_to_subdomain
+            model = public_send("current_#{scope}").class
+            return if (scoped_to_subdomain && request.subdomain != model.scoped_to_subdomain) ||
+                (neglect_subdomain && request.subdomain == model.neglect_subdomain)
           rescue => e
           end
           redirect_to two_factor_authentication_path_for(scope)

--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -12,7 +12,8 @@ module TwoFactorAuthentication
       def handle_two_factor_authentication
         unless devise_controller?
           Devise.mappings.keys.flatten.any? do |scope|
-            if signed_in?(scope) and warden.session(scope)[TwoFactorAuthentication::NEED_AUTHENTICATION]
+            if signed_in?(scope) and warden.session(scope)[TwoFactorAuthentication::name_for(:need_authentication,
+                                                                                             scope)]
               handle_failed_second_factor(scope)
             end
           end
@@ -22,6 +23,9 @@ module TwoFactorAuthentication
       def handle_failed_second_factor(scope)
         if request.format.present? and request.format.html?
           session["#{scope}_return_to"] = request.original_fullpath if request.get?
+
+          scoped_to_subdomain = public_send("current_#{scope}")&.scoped_to_subdomain
+          return if scoped_to_subdomain && request.subdomain != scoped_to_subdomain
           redirect_to two_factor_authentication_path_for(scope)
         else
           head :unauthorized
@@ -41,8 +45,9 @@ end
 module Devise
   module Controllers
     module Helpers
-      def is_fully_authenticated?
-        !session["warden.user.user.session"].try(:[], TwoFactorAuthentication::NEED_AUTHENTICATION)
+      def is_fully_authenticated?(resource_name)
+        !session["warden.user.user.session"].try(:[], TwoFactorAuthentication::name_for(:need_authentication,
+                                                                                        resource_name))
       end
     end
   end

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -1,17 +1,22 @@
 Warden::Manager.after_authentication do |user, auth, options|
   if auth.env["action_dispatch.cookies"]
     expected_cookie_value = "#{user.class}-#{user.public_send(Devise.second_factor_resource_id)}"
-    actual_cookie_value = auth.env["action_dispatch.cookies"].signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME]
+    actual_cookie_value = auth.env["action_dispatch.cookies"]
+                              .signed[TwoFactorAuthentication::name_for(:remember_tfa_cookie_name,
+                                                                        options[:scope])]
     bypass_by_cookie = actual_cookie_value == expected_cookie_value
   end
 
   if user.respond_to?(:need_two_factor_authentication?) && !bypass_by_cookie
-    if auth.session(options[:scope])[TwoFactorAuthentication::NEED_AUTHENTICATION] = user.need_two_factor_authentication?(auth.request)
+    if auth.session(options[:scope])[TwoFactorAuthentication::name_for(
+        :need_authentication, options[:scope]
+    )] = user.need_two_factor_authentication?(auth.request)
       user.send_new_otp if user.send_new_otp_after_login?
     end
   end
 end
 
 Warden::Manager.before_logout do |user, auth, _options|
-  auth.cookies.delete TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME if Devise.delete_cookie_on_logout
+  auth.cookies.delete TwoFactorAuthentication::name_for(:remember_tfa_cookie_name,
+                                                        _options[:scope]) if Devise.delete_cookie_on_logout
 end

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -10,7 +10,7 @@ Warden::Manager.after_authentication do |user, auth, options|
   if user.respond_to?(:need_two_factor_authentication?) && !bypass_by_cookie
     if auth.session(options[:scope])[TwoFactorAuthentication::name_for(
         :need_authentication, options[:scope]
-    )] = user.need_two_factor_authentication?(auth.request)
+    )] = user.need_two_factor_authentication?(auth.request) and user.class.subdomain_in_scope?
       user.send_new_otp if user.send_new_otp_after_login?
     end
   end

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -10,7 +10,7 @@ Warden::Manager.after_authentication do |user, auth, options|
   if user.respond_to?(:need_two_factor_authentication?) && !bypass_by_cookie
     if auth.session(options[:scope])[TwoFactorAuthentication::name_for(
         :need_authentication, options[:scope]
-    )] = user.need_two_factor_authentication?(auth.request) and user.class.subdomain_in_scope?
+    )] = user.need_two_factor_authentication?(auth.request) and user.class.subdomain_in_scope?(auth.request.subdomain)
       user.send_new_otp if user.send_new_otp_after_login?
     end
   end

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -11,6 +11,7 @@ module Devise
         def has_one_time_password(options = {})
           include InstanceMethodsOnActivation
           include EncryptionInstanceMethods if options[:encrypted] == true
+          extend ClassMethodsOnActivation
         end
 
         ::Devise::Models.config(
@@ -18,6 +19,17 @@ module Devise
           :remember_otp_session_for_seconds, :otp_secret_encryption_key,
           :direct_otp_length, :direct_otp_valid_for, :totp_timestamp, :delete_cookie_on_logout
         )
+      end
+
+      module ClassMethodsOnActivation
+        def subdomain_in_scope?
+          begin
+            false if (scoped_to_subdomain && request.subdomain != scoped_to_subdomain) ||
+                (neglect_subdomain && request.subdomain == neglect_subdomain)
+          rescue
+            true
+          end
+        end
       end
 
       module InstanceMethodsOnActivation
@@ -99,15 +111,6 @@ module Devise
             direct_otp: random_base10(digits),
             direct_otp_sent_at: Time.now.utc
           )
-        end
-
-        def subdomain_in_scope?
-          begin
-              false if (scoped_to_subdomain && request.subdomain != scoped_to_subdomain) ||
-              (neglect_subdomain && request.subdomain == neglect_subdomain)
-          rescue
-            true
-          end
         end
 
         private

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -23,8 +23,8 @@ module Devise
 
       module ClassMethodsOnActivation
         def subdomain_in_scope?(subdomain)
-          (respond_to?(:scoped_to_subdomain) && subdomain == scoped_to_subdomain) ||
-              (respond_to?(:neglect_subdomain) && subdomain != neglect_subdomain)
+          return true unless respond_to? :two_factor_subdomains
+          !!(subdomain =~ two_factor_subdomains)
         end
       end
 

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -23,12 +23,8 @@ module Devise
 
       module ClassMethodsOnActivation
         def subdomain_in_scope?(subdomain)
-          begin
-            false if (scoped_to_subdomain && subdomain != scoped_to_subdomain) ||
-                (neglect_subdomain && subdomain == neglect_subdomain)
-          rescue
-            true
-          end
+          (respond_to?(:scoped_to_subdomain) && subdomain == scoped_to_subdomain) ||
+              (respond_to?(:neglect_subdomain) && subdomain != neglect_subdomain)
         end
       end
 

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -101,6 +101,15 @@ module Devise
           )
         end
 
+        def subdomain_in_scope?
+          begin
+              false if (scoped_to_subdomain && request.subdomain != scoped_to_subdomain) ||
+              (neglect_subdomain && request.subdomain == neglect_subdomain)
+          rescue
+            true
+          end
+        end
+
         private
 
         def without_spaces(code)

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -22,10 +22,10 @@ module Devise
       end
 
       module ClassMethodsOnActivation
-        def subdomain_in_scope?
+        def subdomain_in_scope?(subdomain)
           begin
-            false if (scoped_to_subdomain && request.subdomain != scoped_to_subdomain) ||
-                (neglect_subdomain && request.subdomain == neglect_subdomain)
+            false if (scoped_to_subdomain && subdomain != scoped_to_subdomain) ||
+                (neglect_subdomain && subdomain == neglect_subdomain)
           rescue
             true
           end

--- a/spec/controllers/two_factor_authentication_controller_spec.rb
+++ b/spec/controllers/two_factor_authentication_controller_spec.rb
@@ -18,7 +18,7 @@ describe Devise::TwoFactorAuthenticationController, type: :controller do
       it 'returns true' do
         controller.current_user.send_new_otp
         post_code controller.current_user.direct_otp
-        expect(subject.is_fully_authenticated?).to eq true
+        expect(subject.is_fully_authenticated?("user")).to eq true
       end
     end
 
@@ -26,7 +26,7 @@ describe Devise::TwoFactorAuthenticationController, type: :controller do
       it 'returns false' do
         get :show
 
-        expect(subject.is_fully_authenticated?).to eq false
+        expect(subject.is_fully_authenticated?("user")).to eq false
       end
     end
 
@@ -34,7 +34,7 @@ describe Devise::TwoFactorAuthenticationController, type: :controller do
       it 'returns false' do
         post_code '12345'
 
-        expect(subject.is_fully_authenticated?).to eq false
+        expect(subject.is_fully_authenticated?("user")).to eq false
       end
     end
   end

--- a/spec/features/two_factor_authenticatable_spec.rb
+++ b/spec/features/two_factor_authenticatable_spec.rb
@@ -189,7 +189,7 @@ feature "User of two factor authentication" do
     end
 
     it 'sets the warden session need_two_factor_authentication key to true' do
-      session_hash = { 'need_two_factor_authentication' => true }
+      session_hash = { 'need_two_factor_authentication_user' => true }
 
       expect(page.get_rack_session_key('warden.user.user.session')).to eq session_hash
     end

--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -323,4 +323,31 @@ describe Devise::Models::TwoFactorAuthenticatable do
       end
     end
   end
+
+  describe 'self.subdomain_in_scope?' do
+    let(:user) { EncryptedUser.new }
+
+    it 'allows scope if no optional methods' do
+      expect(user.class.subdomain_in_scope?('test1'))
+    end
+
+    it 'correctly parses a regex (neglect example)' do
+      allow(user.class).to receive(:two_factor_subdomains).and_return /^(?!(bad)$).*$/
+
+      expect(user.class.subdomain_in_scope?('good')).to be(true)
+      expect(user.class.subdomain_in_scope?('another-one')).to be(true)
+      expect(user.class.subdomain_in_scope?('bad')).to be(false)
+      expect(user.class.subdomain_in_scope?('goodbadugly')).to be(true)
+      expect(user.class.subdomain_in_scope?('')).to be(true)
+    end
+
+    it 'correctly parses a regex (whitelist example)' do
+      allow(user.class).to receive(:two_factor_subdomains).and_return /^(good|ugly)$/
+
+      expect(user.class.subdomain_in_scope?('good')).to be(true)
+      expect(user.class.subdomain_in_scope?('ugly')).to be(true)
+      expect(user.class.subdomain_in_scope?('bad')).to be(false)
+      expect(user.class.subdomain_in_scope?('')).to be(false)
+    end
+  end
 end

--- a/spec/support/controller_helper.rb
+++ b/spec/support/controller_helper.rb
@@ -2,7 +2,7 @@ module ControllerHelper
   def sign_in(user = create_user('not_encrypted'))
     allow(warden).to receive(:authenticated?).with(:user).and_return(true)
     allow(controller).to receive(:current_user).and_return(user)
-    warden.session(:user)[TwoFactorAuthentication::NEED_AUTHENTICATION] = true
+    warden.session(:user)[TwoFactorAuthentication::name_for(:need_authentication, "user")] = true
   end
 end
 

--- a/spec/support/features_spec_helper.rb
+++ b/spec/support/features_spec_helper.rb
@@ -20,11 +20,11 @@ module FeaturesSpecHelper
   end
 
   def set_tfa_cookie value
-    set_cookie TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME, value
+    set_cookie TwoFactorAuthentication::name_for(:remember_tfa_cookie_name, "user"), value
   end
 
   def get_tfa_cookie
-    get_cookie TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME
+    get_cookie TwoFactorAuthentication::name_for(:remember_tfa_cookie_name, "user")
   end
 end
 


### PR DESCRIPTION
Hello,

I was using your gem for a long while and I liked it a lot. However, it did not quite work with me well where I was having two user scopes and different subdomains.

In my scenario AdminUser should have been available on "system.example.com" subdomain and User should have been on "portal.example.com", "blog.example.com", "docs.example.com" and "example.com" itself.

I separated session cookie store so that there were two different cookies created for these separations: _core_session and _admin_session

Problem with this gem #1 was that it was creating single "remember_tfa" cookie that arose problems with other scopes.

Problem #2 was that if I logged-in in system.example.com as AdminUser and I was prompted 2FA, if I would not enter anything in the box and manually head to portal.example.com or docs.example com I would be force-redirected back to system.example.com and this was very disturbing.

Feel free to reject this pull-request, or perhaps introduce a better solution but for me this was handy.

**USAGE**

1) Cookie name - done automatically
2) Subdomain scopes - Optional
Your devise models can now have two optional class methods _neglect_subdomain_ and _scoped_to_subdomain_ which have to return a string (i.e. "portal")

I would really appreciate if you could introduce your version of this PR.

Thanks,
Dachi