### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,6 @@ to set TOTP to DISABLED for a user account:
    current_user.totp_timestamp=nil
    current_user.direct_otp=nil
    current_user.otp_secret_key=nil
-   current_user.otp_confirmed=nil
    current_user.save! (if in ruby code instead of console)
    current_user.direct_otp? => false
    current_user.totp_enabled? => false


### PR DESCRIPTION
It states in the documentation that to fully disable `TOTP`, we need to set `otp_confirmed` to `nil` but it looks like this column only exists in readme.