### PR TITLE
Use ROTP::Base32.random instead of ROTP::Base32.random_base32 if available

### DIFF
--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -92,7 +92,7 @@ module Devise
         end
 
         def generate_totp_secret
-          ROTP::Base32.random_base32
+          ROTP::Base32.try(:random) || ROTP::Base32.random_base32
         end
 
         def create_direct_otp(options = {})


### PR DESCRIPTION
Newer versions of the ROTP gem use a different method for getting a random base32 string. This feature just checks if the random method is available, if not it uses random_base32.