### PR TITLE
change prepend_before_action to before_action

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -1,7 +1,7 @@
 require 'devise/version'
 
 class Devise::TwoFactorAuthenticationController < DeviseController
-  prepend_before_action :authenticate_scope!
+  before_action :authenticate_scope!
   before_action :prepare_and_validate, :handle_two_factor_authentication
 
   def show


### PR DESCRIPTION
The `authenticate_scope!` has been prepended to the callbacks list. It is not required to prepend this function and it sometimes even breaks some functionalities because it is prepended:

We have a default scope on our resource model that sets a tenant according to the domain name (using: https://github.com/ErwinM/acts_as_tenant). Setting the tenant value required for finding the correct user is done in a `prepend_before_action` of our own. Because of the default scope, the `authenticate_scope! method is not able to find the correct user, because the tenant has not been set yet.

I think that changing the `prepend_before_action` to `before_action` would be better as the developer is able to change scopes and perform other actions before the user lookup is done in `authenticate_scope!`.