### PR TITLE
Use create date over expiry on remember 2fa cookie

### DIFF
--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -46,7 +46,11 @@ class Devise::TwoFactorAuthenticationController < DeviseController
 
     if expires_seconds && expires_seconds > 0
       cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {
-          value: "#{resource.class}-#{resource.public_send(Devise.second_factor_resource_id)}",
+          value: {
+            user_class: resource.class.to_s,
+            user_id: resource.public_send(Devise.second_factor_resource_id).to_s,
+            created_at: Time.current
+          },
           expires: expires_seconds.seconds.from_now
       }
     end

--- a/spec/features/two_factor_authenticatable_spec.rb
+++ b/spec/features/two_factor_authenticatable_spec.rb
@@ -136,6 +136,19 @@ feature "User of two factor authentication" do
         expect(page).to have_content("Enter the code that was sent to you")
       end
 
+      scenario "requires TFA code again after if expiry date changes" do
+        sms_sign_in
+
+        logout
+
+        User.remember_otp_session_for_seconds = 1.day
+        Timecop.travel(1.day.from_now)
+        login_as user
+        visit dashboard_path
+        expect(page).to have_content("You are signed in as Marissa")
+        expect(page).to have_content("Enter the code that was sent to you")
+      end
+
       scenario 'TFA should be different for different users' do
         sms_sign_in
 


### PR DESCRIPTION
If a remember 2fa cookie is issued expiring in 30 days and the server is
updated with a new value for `remember_otp_session_for_seconds`, the
cookie will still be valid for 30 days, as the final date was set on it.

To get around that, timestamp the cookie and compare that to the current
setting on the server.