### PR TITLE
Skip validations when setting direct_otp

### DIFF
--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -61,7 +61,7 @@ module Devise
         end
 
         def send_new_otp(options = {})
-          create_direct_otp options
+          create_direct_otp(options)
           send_two_factor_authentication_code(direct_otp)
         end
 
@@ -101,9 +101,10 @@ module Devise
         def create_direct_otp(options = {})
           # Create a new random OTP and store it in the database
           digits = options[:length] || self.class.direct_otp_length || 6
-          self.direct_otp = random_base10(digits)
-          self.direct_otp_sent_at = Time.now.utc
-          save(validate: false)
+          update_columns(
+            direct_otp: random_base10(digits),
+            direct_otp_sent_at: Time.now.utc
+          )
         end
 
         private
@@ -121,9 +122,10 @@ module Devise
         end
 
         def clear_direct_otp
-          self.direct_otp = nil
-          self.direct_otp_sent_at = nil
-          save(validate: false)
+          update_columns(
+            direct_otp: nil,
+            direct_otp_sent_at: nil
+          )
         end
       end
 

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -101,10 +101,9 @@ module Devise
         def create_direct_otp(options = {})
           # Create a new random OTP and store it in the database
           digits = options[:length] || self.class.direct_otp_length || 6
-          update_attributes(
-            direct_otp: random_base10(digits),
-            direct_otp_sent_at: Time.now.utc
-          )
+          self.direct_otp = random_base10(digits)
+          self.direct_otp_sent_at = Time.now.utc
+          save(validate: false)
         end
 
         private
@@ -122,7 +121,9 @@ module Devise
         end
 
         def clear_direct_otp
-          update_attributes(direct_otp: nil, direct_otp_sent_at: nil)
+          self.direct_otp = nil
+          self.direct_otp_sent_at = nil
+          save(validate: false)
         end
       end
 


### PR DESCRIPTION
If there is a validation error on the user model, it can lead to some unpredictable 2FA behavior. For example, the `send_new_otp` method will send a new OTP code to the user even if it failed to update the `direct_otp` column in the database. When this happens, the new code does not work for the user.

Looking at other devise modules, they tend to skip validations when saving data as well:

- https://github.com/plataformatec/devise/blob/master/lib/devise/models/trackable.rb#L40
- https://github.com/plataformatec/devise/blob/master/lib/devise/models/rememberable.rb#L53
- https://github.com/plataformatec/devise/blob/master/lib/devise/models/rememberable.rb#L62
- https://github.com/plataformatec/devise/blob/master/lib/devise/models/recoverable.rb#L94
- https://github.com/plataformatec/devise/blob/master/lib/devise/models/lockable.rb#L48
- https://github.com/plataformatec/devise/blob/master/lib/devise/models/lockable.rb#L57
- https://github.com/plataformatec/devise/blob/master/lib/devise/models/lockable.rb#L69
- https://github.com/plataformatec/devise/blob/master/lib/devise/models/lockable.rb#L108
- https://github.com/plataformatec/devise/blob/master/lib/devise/models/confirmable.rb#L258

It seems like generating the `direct_otp` token is similar to a lot of these other cases where validation is skipped.

This should also fix #170 