### PR TITLE
Add Devise.available_router_name to support routing correctly with engines

### DIFF
--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -35,8 +35,13 @@ module TwoFactorAuthentication
 
       def two_factor_authentication_path_for(resource_or_scope = nil)
         scope = Devise::Mapping.find_scope!(resource_or_scope)
+        namespace = if Devise.available_router_name
+          send(Devise.available_router_name)
+        else
+          self
+        end
         change_path = "#{scope}_two_factor_authentication_path"
-        send(change_path)
+        namespace.send(change_path)
       end
 
     end


### PR DESCRIPTION
Problem
---
- When an app has an engine, the rails routes for that engine are prefixed with some engine scope (let's say `my_engine` for this issue)
- By default, rails will look in the `my_engine` when going to a URL within that engine
- The controller in the engine is not a `devise_controller`, so 2FA gets applied.
- However, just using `send(change_path)` is not enough as we will look for `scope_two_factor_authentication_path` in the current app/engine. So this ends up meaning `my_engine.scope_two_factor_authentication_path`

Solution
---

- By sending it to `Devise.available_router_name` instead, we get `main_app.scope_two_factor_authentication_path` (or whatever the router name is) and everything works from within the engine

I couldn't get tests to run locally, otherwise, I'll try to get a test written