### PR TITLE
Improvements to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ config.otp_length = 6  # TOTP code length
 config.direct_otp_valid_for = 5.minutes  # Time before direct OTP becomes invalid
 config.direct_otp_length = 6  # Direct OTP code length
 config.remember_otp_session_for_seconds = 30.days  # Time before browser has to perform 2fA again. Default is 0.
-config.otp_secret_encryption_key = ENV['OTP_SECRET_ENCRYPTION_KEY']
+config.otp_secret_encryption_key = ENV['OTP_SECRET_ENCRYPTION_KEY'] # Can be also a lambda
 config.second_factor_resource_id = 'id' # Field or method name used to set value for 2fA remember cookie
 config.delete_cookie_on_logout = false # Delete cookie when user signs out, to force 2fA again on login
 ```

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -42,7 +42,11 @@ class Devise::TwoFactorAuthenticationController < DeviseController
   end
 
   def set_remember_two_factor_cookie(resource)
-    expires_seconds = resource.class.remember_otp_session_for_seconds
+    expires_seconds = if resource.respond_to?(:remember_otp_session_for_seconds)
+      resource.remember_otp_session_for_seconds
+    else
+      resource.class.remember_otp_session_for_seconds
+    end
 
     if expires_seconds && expires_seconds > 0
       cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -24,8 +24,8 @@ class Devise::TwoFactorAuthenticationController < DeviseController
 
   private
 
-  def after_two_factor_success_for(resource)
-    set_remember_two_factor_cookie(resource)
+  def after_two_factor_success_for(resource, options = {})
+    set_remember_two_factor_cookie(resource, options)
 
     warden.session(resource_name)[TwoFactorAuthentication::NEED_AUTHENTICATION] = false
     # For compatability with devise versions below v4.2.0

--- a/app/controllers/devise/two_factor_authentication_controller.rb
+++ b/app/controllers/devise/two_factor_authentication_controller.rb
@@ -41,7 +41,7 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     redirect_to after_two_factor_success_path_for(resource)
   end
 
-  def set_remember_two_factor_cookie(resource)
+  def set_remember_two_factor_cookie(resource, options = {})
     expires_seconds = if resource.respond_to?(:remember_otp_session_for_seconds)
       resource.remember_otp_session_for_seconds
     else
@@ -51,7 +51,10 @@ class Devise::TwoFactorAuthenticationController < DeviseController
     if expires_seconds && expires_seconds > 0
       cookies.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME] = {
           value: "#{resource.class}-#{resource.public_send(Devise.second_factor_resource_id)}",
-          expires: expires_seconds.seconds.from_now
+          expires: expires_seconds.seconds.from_now,
+          httponly: options[:httponly] || nil,
+          secure: options[:secure] || nil,
+          same_site: options[:same_site] || nil
       }
     end
   end

--- a/lib/two_factor_authentication.rb
+++ b/lib/two_factor_authentication.rb
@@ -24,14 +24,23 @@ module Devise
   mattr_accessor :remember_otp_session_for_seconds
   @@remember_otp_session_for_seconds = 0
 
-  mattr_accessor :otp_secret_encryption_key
-  @@otp_secret_encryption_key = ''
-
   mattr_accessor :second_factor_resource_id
   @@second_factor_resource_id = 'id'
 
   mattr_accessor :delete_cookie_on_logout
   @@delete_cookie_on_logout = false
+
+  mattr_writer :otp_secret_encryption_key
+  @@otp_secret_encryption_key = ''
+
+  def self.otp_secret_encryption_key
+    if @@otp_secret_encryption_key.respond_to?(:call)
+      @@otp_secret_encryption_key.call
+    else
+      @@otp_secret_encryption_key
+    end
+  end
+  delegate :otp_secret_encryption_key, to: 'self.class'
 end
 
 module TwoFactorAuthentication

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -17,7 +17,7 @@ Warden::Manager.before_logout do |user, auth, _options|
   should_delete = Devise.delete_cookie_on_logout
   
   if user.respond_to?(:delete_cookie_on_logout?)
-    should_delete = user.delete_cookie_on_logout
+    should_delete = user.delete_cookie_on_logout?
   end
 
   auth.cookies.delete TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME if should_delete

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -13,5 +13,11 @@ Warden::Manager.after_authentication do |user, auth, options|
 end
 
 Warden::Manager.before_logout do |user, auth, _options|
-  auth.cookies.delete TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME if Devise.delete_cookie_on_logout
+  should_delete = Devise.delete_cookie_on_logout
+  
+  if user.respond_to?(:delete_cookie_on_logout?)
+    should_delete = user.delete_cookie_on_logout
+  end
+
+  auth.cookies.delete TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME if should_delete
 end

--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -1,7 +1,8 @@
 Warden::Manager.after_authentication do |user, auth, options|
-  if auth.env["action_dispatch.cookies"]
+  cookie_jar = auth.cookies || auth.env["action_dispatch.cookies"]
+  if cookie_jar
     expected_cookie_value = "#{user.class}-#{user.public_send(Devise.second_factor_resource_id)}"
-    actual_cookie_value = auth.env["action_dispatch.cookies"].signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME]
+    actual_cookie_value = cookie_jar.signed[TwoFactorAuthentication::REMEMBER_TFA_COOKIE_NAME]
     bypass_by_cookie = actual_cookie_value == expected_cookie_value
   end
 

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -36,7 +36,7 @@ module Devise
         def authenticate_totp(code, options = {})
           totp_secret = options[:otp_secret_key] || otp_secret_key
           digits = options[:otp_length] || (self.respond_to?(:otp_length) && self.otp_length) || self.class.otp_length
-          drift = options[:drift] || self.class.allowed_otp_drift_seconds
+          drift = options[:drift] || (self.respond_to?(:allowed_otp_drift_seconds) && self.allowed_otp_drift_seconds) || self.class.allowed_otp_drift_seconds
           raise "authenticate_totp called with no otp_secret_key set" if totp_secret.nil?
           totp = ROTP::TOTP.new(totp_secret, digits: digits)
           new_timestamp = totp.verify(

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -170,11 +170,19 @@ module Devise
         def encryption_options_for(value)
           {
             value: value,
-            key: Devise.otp_secret_encryption_key,
+            key: otp_secret_encryption_key,
             iv: iv_for_attribute,
             salt: salt_for_attribute,
             algorithm: 'aes-256-cbc'
           }
+        end
+
+        def otp_secret_encryption_key
+          if self.respond_to?(:otp_secret_encryption_key)
+            self.otp_secret_encryption_key
+          else
+            Devise.otp_secret_encryption_key
+          end
         end
 
         def iv_for_attribute(algorithm = 'aes-256-cbc')

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -44,7 +44,9 @@ module Devise
             drift_ahead: drift, drift_behind: drift, after: totp_timestamp
           )
           return false unless new_timestamp
-          self.totp_timestamp = new_timestamp
+          # ROTP returns the matched timestamp as a Unix epoch Integer;
+          # coerce it so the datetime column casts it correctly
+          self.totp_timestamp = Time.zone.at(new_timestamp)
           true
         end
 
@@ -105,7 +107,7 @@ module Devise
         def create_direct_otp(options = {})
           # Create a new random OTP and store it in the database
           digits = options[:length] || (self.respond_to?(:direct_otp_length) && self.direct_otp_length) || self.class.direct_otp_length || 6
-          update_attributes(
+          update(
             direct_otp: random_base10(digits),
             direct_otp_sent_at: Time.now.utc
           )
@@ -126,7 +128,7 @@ module Devise
         end
 
         def clear_direct_otp
-          update_attributes(direct_otp: nil, direct_otp_sent_at: nil)
+          update(direct_otp: nil, direct_otp_sent_at: nil)
         end
       end
 

--- a/lib/two_factor_authentication/routes.rb
+++ b/lib/two_factor_authentication/routes.rb
@@ -3,7 +3,7 @@ module ActionDispatch::Routing
     protected
 
       def devise_two_factor_authentication(mapping, controllers)
-        resource :two_factor_authentication, :only => [:show, :update, :resend_code], :path => mapping.path_names[:two_factor_authentication], :controller => controllers[:two_factor_authentication] do
+        resource :two_factor_authentication, :only => [:show, :update], :path => mapping.path_names[:two_factor_authentication], :controller => controllers[:two_factor_authentication] do
           collection { get "resend_code" }
         end
       end

--- a/lib/two_factor_authentication/version.rb
+++ b/lib/two_factor_authentication/version.rb
@@ -1,3 +1,3 @@
 module TwoFactorAuthentication
-  VERSION = "2.3.1".freeze
+  VERSION = "2.3.2".freeze
 end

--- a/lib/two_factor_authentication/version.rb
+++ b/lib/two_factor_authentication/version.rb
@@ -1,3 +1,3 @@
 module TwoFactorAuthentication
-  VERSION = "2.2.0".freeze
+  VERSION = "2.3.0".freeze
 end

--- a/lib/two_factor_authentication/version.rb
+++ b/lib/two_factor_authentication/version.rb
@@ -1,3 +1,3 @@
 module TwoFactorAuthentication
-  VERSION = "2.3.0".freeze
+  VERSION = "2.3.1".freeze
 end

--- a/spec/rails_app/app/models/guest_user.rb
+++ b/spec/rails_app/app/models/guest_user.rb
@@ -7,7 +7,7 @@ class GuestUser
   attr_accessor :direct_otp, :direct_otp_sent_at, :otp_secret_key, :email,
     :second_factor_attempts_count, :totp_timestamp
 
-  def update_attributes(attrs)
+  def update(attrs)
     attrs.each do |key, value|
       send(key.to_s + '=', value)
     end


### PR DESCRIPTION
This PR improves configuration options by adding an ability for more "dynamic" configuration

- use lambda function to configure `otp_secret_encryption_key` (i.e. if encryption key is known in runtime)
- add support for instance methods
  - `remember_otp_session_for_seconds`
  - `delete_cookie_on_logout`
  - `allowed_otp_drift_seconds`
  - `otp_length`