### PR TITLE
Fix handle failed second factor

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,9 @@
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
 require "bundler/gem_tasks"
 
 APP_RAKEFILE = File.expand_path("../spec/rails_app/Rakefile", __FILE__)

--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -20,14 +20,12 @@ module TwoFactorAuthentication
       end
 
       def handle_failed_second_factor(scope)
-        if request.format.present?
-          if request.format.html?
-            session["#{scope}_return_to"] = request.original_fullpath if request.get?
-            redirect_to two_factor_authentication_path_for(scope)
-          elsif request.format.json?
-            session["#{scope}_return_to"] = root_path(format: :html)
-            render json: { redirect_to: two_factor_authentication_path_for(scope) }, status: :unauthorized
-          end
+        if request.format&.html?
+          session["#{scope}_return_to"] = request.original_fullpath if request.get?
+          redirect_to two_factor_authentication_path_for(scope)
+        elsif request.format&.json?
+          session["#{scope}_return_to"] = root_path(format: :html)
+          render json: { redirect_to: two_factor_authentication_path_for(scope) }, status: :unauthorized
         else
           head :unauthorized
         end

--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -101,7 +101,7 @@ module Devise
         def create_direct_otp(options = {})
           # Create a new random OTP and store it in the database
           digits = options[:length] || self.class.direct_otp_length || 6
-          update_attributes(
+          update(
             direct_otp: random_base10(digits),
             direct_otp_sent_at: Time.now.utc
           )
@@ -122,7 +122,7 @@ module Devise
         end
 
         def clear_direct_otp
-          update_attributes(direct_otp: nil, direct_otp_sent_at: nil)
+          update(direct_otp: nil, direct_otp_sent_at: nil)
         end
       end
 

--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -138,7 +138,7 @@ describe Devise::Models::TwoFactorAuthenticatable do
 
         it "returns uri with user's email" do
           expect(instance.provisioning_uri).
-            to match(%r{otpauth://totp/houdini@example.com\?secret=\w{32}})
+            to match(%r{otpauth://totp/houdini%40example.com\?secret=\w{32}})
         end
 
         it 'returns uri with issuer option' do

--- a/spec/rails_app/app/assets/config/manifest.js
+++ b/spec/rails_app/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link application.css
+//= link application.js

--- a/spec/rails_app/app/models/guest_user.rb
+++ b/spec/rails_app/app/models/guest_user.rb
@@ -7,7 +7,7 @@ class GuestUser
   attr_accessor :direct_otp, :direct_otp_sent_at, :otp_secret_key, :email,
     :second_factor_attempts_count, :totp_timestamp
 
-  def update_attributes(attrs)
+  def update(attrs)
     attrs.each do |key, value|
       send(key.to_s + '=', value)
     end


### PR DESCRIPTION
Fix handle_failed_second_factor so that it just doesn't fall through if the request format is something else than html or json