### PR TITLE
Make current migration safe using index concurrently

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -1,4 +1,6 @@
 class TwoFactorAuthenticationAddTo<%= table_name.camelize %> < ActiveRecord::Migration
+  disable_ddl_transaction!
+
   def change
     add_column :<%= table_name %>, :second_factor_attempts_count, :integer, default: 0
     add_column :<%= table_name %>, :encrypted_otp_secret_key, :string
@@ -8,6 +10,6 @@ class TwoFactorAuthenticationAddTo<%= table_name.camelize %> < ActiveRecord::Mig
     add_column :<%= table_name %>, :direct_otp_sent_at, :datetime
     add_column :<%= table_name %>, :totp_timestamp, :timestamp
 
-    add_index :<%= table_name %>, :encrypted_otp_secret_key, unique: true
+    add_index :<%= table_name %>, :encrypted_otp_secret_key, unique: true, algorithm: :concurrently
   end
 end


### PR DESCRIPTION
The current approach is not great for bigger user bases. I added change to make it safer but to use `algorithm: concurrently` I had to disable transaction, which shouldn't be problem in our case.