### PR TITLE
Fixes #169 rotp returning url encoded at

### DIFF
--- a/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
+++ b/spec/lib/two_factor_authentication/models/two_factor_authenticatable_spec.rb
@@ -138,7 +138,7 @@ describe Devise::Models::TwoFactorAuthenticatable do
 
         it "returns uri with user's email" do
           expect(instance.provisioning_uri).
-            to match(%r{otpauth://totp/houdini@example.com\?secret=\w{32}})
+            to match(%r{otpauth://totp/houdini%40example.com\?secret=\w{32}})
         end
 
         it 'returns uri with issuer option' do


### PR DESCRIPTION
Fix #169 
Tests fail for ROTP encoding `@` sign.