### PR TITLE
Fix format vector

### DIFF
--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -27,6 +27,8 @@ module TwoFactorAuthentication
           elsif request.format.json?
             session["#{scope}_return_to"] = root_path(format: :html)
             render json: { redirect_to: two_factor_authentication_path_for(scope) }, status: :unauthorized
+          else
+            head :unauthorized
           end
         else
           head :unauthorized


### PR DESCRIPTION
It looks like a9e9093de8e1c0564d4bb1ed97ca693274b51409 broke the catch-all unauthorized response.

This means that a request with e.g. `Accept: */*` will bypass the guard and return a 200 rather than a 401.