### PR TITLE
fix: Change update_attributes to update

### DIFF
--- a/lib/two_factor_authentication/models/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/models/two_factor_authenticatable.rb
@@ -101,7 +101,7 @@ module Devise
         def create_direct_otp(options = {})
           # Create a new random OTP and store it in the database
           digits = options[:length] || self.class.direct_otp_length || 6
-          update_attributes(
+          update(
             direct_otp: random_base10(digits),
             direct_otp_sent_at: Time.now.utc
           )
@@ -122,7 +122,7 @@ module Devise
         end
 
         def clear_direct_otp
-          update_attributes(direct_otp: nil, direct_otp_sent_at: nil)
+          update(direct_otp: nil, direct_otp_sent_at: nil)
         end
       end
 


### PR DESCRIPTION
Deacuerdo a la actualizacion de rails 6, los metodos update_atrributes quedaran deprecados, se hizo el cambio en esta gema para fixear temporalmente este punto de seguridad.