### PR TITLE
Fix ruby3.2 deprecation exists? is now exist?

### DIFF
--- a/lib/generators/two_factor_authentication/two_factor_authentication_generator.rb
+++ b/lib/generators/two_factor_authentication/two_factor_authentication_generator.rb
@@ -7,7 +7,7 @@ module TwoFactorAuthenticatable
 
       def inject_two_factor_authentication_content
         path = File.join("app", "models", "#{file_path}.rb")
-        inject_into_file(path, "two_factor_authenticatable, :", :after => "devise :") if File.exists?(path)
+        inject_into_file(path, "two_factor_authenticatable, :", :after => "devise :") if File.exist?(path)
       end
 
       hook_for :orm


### PR DESCRIPTION
On Ruby versions 3.2 and greater, exists? is deprecated and has been replace with exist?
Without this fix, the rails g two_factor_authentication MODEL generator will fail with:

undefined method `exists?' for File:Class (NoMethodError)

inject_into_file(path, "two_factor_authenticatable, :", :after => "devise :") if File.exists?(path)